### PR TITLE
Failed to detect os name on an 32-bit windows machine during "vuls.exe scan" execution

### DIFF
--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -805,7 +805,7 @@ func formatArch(arch string) (string, error) {
 		return "ARM64-based", nil
 	case "IA64", "Itanium-based":
 		return "Itanium-based", nil
-	case "x86", "X86-based":
+	case "x86", "X86-based", "32-bit":
 		return "32-bit", nil
 	default:
 		return "", xerrors.New("CPU Architecture not found")


### PR DESCRIPTION
During scanning an 32-bit windows machine, "Failed to detect os name." error occured. By investigation, it is found that formatArch function is called twice during scanning. When first time it is called, it converts the os arch string to "32-bit" , but when it is called second time, with input string 32-bit, it returns "unknown architecture" as there is no switch case to handle "32-bit" case. formatArch function is updated to match proper "x86" or "32-bit" switch case and make the scan to progress and successful.

Fixes # (issue)
time="Jul 17 10:34:40" level=info msg="Detecting OS of servers... "
time="Jul 17 10:34:52" level=error msg="(1/1) Failed: 127.0.0.1, err: [Failed to detect os name. err:\n github.com/future-architect/vuls/scanner.detectWindows\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:87\n - Failed to detect OS Name from OSInfo: {productName:Windows 10 Pro version:10.0 build:19045 revision:6093 edition:Professional servicePack: arch:32-bit installationType:Client}, err:\n github.com/future-architect/vuls/scanner.detectOSName\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:589\n - CPU Architecture not found:\n github.com/future-architect/vuls/scanner.formatArch\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:811]"

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Executed "vuls scan" and "vuls report" command on both 32-bit and 64-bit windows and test result successful on both cases.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** 
YES

